### PR TITLE
read from preset.options.targets instead of preset.targets

### DIFF
--- a/src/util/get-babel-config/get-babel-config.ts
+++ b/src/util/get-babel-config/get-babel-config.ts
@@ -115,7 +115,7 @@ export function getBabelConfig({babelConfig, cwd, forcedOptions = {}, defaultOpt
 							...FORCED_BABEL_PRESET_ENV_OPTIONS,
 							// If targets have already been provided by the user options, accept them.
 							// Otherwise, apply the browserslist as the preset-env target
-							...(preset.targets != null
+							...(preset.options != null && preset.options.targets != null
 								? {}
 								: {
 										targets: {


### PR DESCRIPTION
I believe this is a simple bugfix. The plugin was ignoring/clobbering my preset-env targets, and I tracked it down to this, where it's reading seemingly the wrong property. Please let me know if you need anything more from me before you can merge this 🙇 