### PR TITLE
add lib.2018.asyncgenerator to default lib names

### DIFF
--- a/src/constant/constant.ts
+++ b/src/constant/constant.ts
@@ -128,6 +128,7 @@ export const DEFAULT_LIB_NAMES: Set<string> = new Set([
 	"lib.es2018.promise.d.ts",
 	"lib.es2018.regexp.d.ts",
 	"lib.es2018.asynciterable.d.ts",
+	"lib.es2018.asyncgenerator.d.ts",
 	"lib.es2019.array.d.ts",
 	"lib.es2019.d.ts",
 	"lib.es2019.full.d.ts",


### PR DESCRIPTION
This PR just adds `"lib.es2018.asyncgenerator.d.ts"` to the set of [`DEFAULT_LIB_NAMES`](https://github.com/wessberg/rollup-plugin-ts/blob/master/src/constant/constant.ts#L99) in order to get the plugin working with TypeScript 3.6

See https://github.com/microsoft/TypeScript/pull/30790