### PR TITLE
feat: allow to override the search base of the LIB_DIRECTORY lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ In comparison with the [official plugin](https://github.com/rollup/rollup-plugin
   - [`tsconfig`](#tsconfig)
   - [`browserslist`](#browserslist)
   - [`cwd`](#cwd)
+  - [`resolveTypescriptLibFrom`](#resolvetypescriptlibfrom)
   - [`transformers`](#transformers)
   - [`include`](#include)
   - [`exclude`](#exclude)
@@ -461,6 +462,12 @@ See [this section](#combining-typescript-with-a-browserslist) for details on the
 Type: `string`
 
 Use this property to overwrite whatever is considered the root directory. The default value is `process.cwd()`.
+
+#### `resolveTypescriptLibFrom`
+
+Type: `string`
+
+Use this property to overwrite from where to search for the `node_modules/typescript/lib` directory. The default value is `cwd`.
 
 #### `transformers`
 

--- a/src/plugin/i-typescript-plugin-options.ts
+++ b/src/plugin/i-typescript-plugin-options.ts
@@ -40,6 +40,7 @@ export interface ITypescriptPluginBaseOptions {
 		| TsConfigResolverWithFileName;
 	browserslist?: false | string[] | string | BrowserslistConfig;
 	cwd: string;
+	resolveTypescriptLibFrom: string;
 	transformers?: (CustomTransformers | CustomTransformersFunction)[] | CustomTransformers | CustomTransformersFunction;
 	include: string[] | string;
 	exclude: string[] | string;

--- a/src/plugin/typescript-plugin.ts
+++ b/src/plugin/typescript-plugin.ts
@@ -67,7 +67,7 @@ const PLUGIN_NAME = "Typescript";
  */
 export default function typescriptRollupPlugin(pluginInputOptions: Partial<TypescriptPluginOptions> = {}): Plugin {
 	const pluginOptions: TypescriptPluginOptions = getPluginOptions(pluginInputOptions);
-	const {include, exclude, tsconfig, cwd, browserslist} = pluginOptions;
+	const {include, exclude, tsconfig, cwd, resolveTypescriptLibFrom, browserslist} = pluginOptions;
 	const transformers = pluginOptions.transformers == null ? [] : ensureArray(pluginOptions.transformers);
 	// Make sure to normalize the received Browserslist
 	const normalizedBrowserslist = getBrowserslist({browserslist, cwd, fileSystem: pluginOptions.fileSystem});
@@ -209,6 +209,7 @@ export default function typescriptRollupPlugin(pluginInputOptions: Partial<Types
 			// Hook up a LanguageServiceHost and a LanguageService
 			languageServiceHost = new IncrementalLanguageService({
 				cwd,
+				resolveTypescriptLibFrom,
 				emitCache,
 				rollupInputOptions,
 				supportedExtensions: SUPPORTED_EXTENSIONS,

--- a/src/service/language-service/i-language-service-options.ts
+++ b/src/service/language-service/i-language-service-options.ts
@@ -8,6 +8,7 @@ import {FileSystem} from "../../util/file-system/file-system";
 export interface ILanguageServiceOptions {
 	parsedCommandLine: ParsedCommandLine;
 	cwd: TypescriptPluginOptions["cwd"];
+	resolveTypescriptLibFrom: TypescriptPluginOptions['resolveTypescriptLibFrom']
 	transformers?: CustomTransformersFunction;
 	emitCache: IEmitCache;
 	rollupInputOptions: InputOptions;

--- a/src/service/language-service/incremental-language-service.ts
+++ b/src/service/language-service/incremental-language-service.ts
@@ -43,7 +43,7 @@ export class IncrementalLanguageService implements LanguageServiceHost, Compiler
 	 * @type {string | null}
 	 */
 
-	private readonly LIB_DIRECTORY = sync("node_modules/typescript/lib", {cwd: this.options.cwd, type: "directory"});
+	private readonly LIB_DIRECTORY = sync("node_modules/typescript/lib", {cwd: this.options.resolveTypescriptLibFrom, type: "directory"});
 
 	/**
 	 * The lookup location for the tslib file

--- a/src/util/plugin-options/get-plugin-options.ts
+++ b/src/util/plugin-options/get-plugin-options.ts
@@ -12,6 +12,7 @@ export function getPluginOptions(options: Partial<TypescriptPluginOptions>): Typ
 		browserslist,
 		transpiler = "typescript",
 		cwd = process.cwd(),
+		resolveTypescriptLibFrom = cwd,
 		tsconfig,
 		transformers,
 		include = [],
@@ -25,6 +26,7 @@ export function getPluginOptions(options: Partial<TypescriptPluginOptions>): Typ
 	const baseOptions = {
 		browserslist,
 		cwd,
+		resolveTypescriptLibFrom,
 		exclude,
 		include,
 		transformers,


### PR DESCRIPTION
In a monorepo setup the `node_modules/typescript/lib` may not be a parent of the current directory. This PR allows top overwrite the lookup base to handle such cases.