### PR TITLE
chore(test): add Github actions workflow

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,46 @@
+name: Main Workflow
+
+on: [push, pull_request]
+
+jobs:
+  run:
+    name: Run
+
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-18.04]
+        node: [8, 10, 13]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+
+      - name: Setup Node.js
+        uses: actions/setup-node@master
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Cache
+        uses: actions/cache@preview
+        id: cache
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-${{ matrix.node }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.node }}-node-
+
+      - name: Install
+        if: steps.cache.outputs.cache-hit != 'true' && matrix.node != 8
+        run: npm ci
+
+      - name: Install
+        if: steps.cache.outputs.cache-hit != 'true' && matrix.node == 8
+        run: npm install --no-package-lock
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test


### PR DESCRIPTION
This PR adds a Github-actions workflow that runs on every commit.

The workflow runs:
 - npm run lint
 - npm test

The workflow runs 6 tests in a matrix of:
 - os: [windows-latest, ubuntu-18.04]
 - node: [8, 10, 13]