### PR TITLE
Use Node resolution for babel and helper modules

### DIFF
--- a/src/service/cache/resolve-cache/resolve-cache.ts
+++ b/src/service/cache/resolve-cache/resolve-cache.ts
@@ -120,6 +120,12 @@ export class ResolveCache implements IResolveCache {
 			}
 		}
 
+		// As a last resort, try Node.js's resolution algorith.
+		// Useful when installed through pnpm.
+		try {
+			return require.resolve(path);
+		} catch (_) {}
+
 		return undefined;
 	}
 

--- a/src/util/get-default-babel-options/get-default-babel-options.ts
+++ b/src/util/get-default-babel-options/get-default-babel-options.ts
@@ -18,7 +18,7 @@ export function getDefaultBabelOptions({browserslist, rollupInputOptions}: IGetD
 				? []
 				: [
 						[
-							"@babel/preset-env",
+							require.resolve("@babel/preset-env"),
 							{
 								...FORCED_BABEL_PRESET_ENV_OPTIONS,
 								// Loose breaks things such as spreading an iterable that isn't an array
@@ -39,15 +39,15 @@ export function getDefaultBabelOptions({browserslist, rollupInputOptions}: IGetD
 			...(includePresetEnv
 				? []
 				: [
-						"@babel/plugin-proposal-object-rest-spread",
-						"@babel/plugin-proposal-async-generator-functions",
-						"@babel/plugin-proposal-optional-catch-binding",
-						"@babel/plugin-proposal-unicode-property-regex",
-						"@babel/plugin-proposal-json-strings"
+						require.resolve("@babel/plugin-proposal-object-rest-spread"),
+						require.resolve("@babel/plugin-proposal-async-generator-functions"),
+						require.resolve("@babel/plugin-proposal-optional-catch-binding"),
+						require.resolve("@babel/plugin-proposal-unicode-property-regex"),
+						require.resolve("@babel/plugin-proposal-json-strings")
 				  ]),
 			// Force the use of helpers (e.g. the runtime). But *don't* apply polyfills.
 			[
-				"@babel/plugin-transform-runtime",
+				require.resolve("@babel/plugin-transform-runtime"),
 				{
 					...FORCED_BABEL_PLUGIN_TRANSFORM_RUNTIME_OPTIONS(rollupInputOptions),
 					corejs: false

--- a/src/util/get-forced-babel-options/get-forced-babel-options.ts
+++ b/src/util/get-forced-babel-options/get-forced-babel-options.ts
@@ -24,7 +24,7 @@ export function getForcedBabelOptions({cwd}: IGetForcedBabelOptionsOptions): IGe
 		sourceType: "module",
 		plugins: [
 			// Needed to make babel understand dynamic imports
-			"@babel/plugin-syntax-dynamic-import"
+			require.resolve("@babel/plugin-syntax-dynamic-import")
 		]
 	};
 }


### PR DESCRIPTION
Allows the plugin to find the modules correctly even when installed through pnpm.

If not given this way, Babel will have a hard time finding the presets and plugins when installed through pnpm, as it tries to find them from the current, which might not have the plugins directly accessible (unless they've manually installed them).

There's a similar problem with typescript not finding tslib; but to be honest TypeScript's codebase scares and confuses me, and I haven't been able to find where to pass an argument for it to find tslib.