### PR TITLE
chore: rename `@wessberg/rollup-plugin-ts` to unscoped `rollup-plugin-ts`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -320,7 +320,7 @@
 
 ### Features
 
-- **EcmaVersion:** adds support for generating browserslists for browsers with support for ES2019 ([2c8ea0c](https://github.com/wessberg/rollup-plugin-ts/commit/2c8ea0c685e25f6d11b1bca3c74ffbe1b0889a79))
+- **EcmaVersion:** adds support for generating browserslist for browsers with support for ES2019 ([2c8ea0c](https://github.com/wessberg/rollup-plugin-ts/commit/2c8ea0c685e25f6d11b1bca3c74ffbe1b0889a79))
 - **typescript:** makes it possible to detect and Ecma version for the ScriptTarget ES2019 ([b336547](https://github.com/wessberg/rollup-plugin-ts/commit/b336547f02657712e11eba5e3d168853be948652))
 
 ## [1.1.43](https://github.com/wessberg/rollup-plugin-ts/compare/v1.1.42...v1.1.43) (2019-03-28)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,9 @@
-You are more than welcome to contribute to `@wessberg/rollup-plugin-ts` in any way you please, including:
+You are more than welcome to contribute to `rollup-plugin-ts` in any way you please, including:
 
 - Updating documentation.
 - Fixing spelling and grammar
 - Adding tests
 - Fixing issues and suggesting new features
-- Blogging, tweeting, and creating tutorials about `@wessberg/rollup-plugin-ts`
+- Blogging, tweeting, and creating tutorials about `rollup-plugin-ts`
 - Reaching out to [@FredWessberg](https://twitter.com/FredWessberg) on Twitter
 - Submit an issue or a Pull Request

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <!-- SHADOW_SECTION_DESCRIPTION_SHORT_START -->
 
-> A Typescript Rollup plugin that bundles declarations and respects Browserslists
+> A Typescript Rollup plugin that bundles declarations and respects Browserslist
 
 <!-- SHADOW_SECTION_DESCRIPTION_SHORT_END -->
 
@@ -28,7 +28,7 @@
 
 <!-- SHADOW_SECTION_DESCRIPTION_LONG_END -->
 
-This is a Rollup plugin that enables integration between Typescript, Babel, Browserslists, and Rollup.
+This is a Rollup plugin that enables integration between Typescript, Babel, Browserslist, and Rollup.
 It is first and foremost a Typescript plugin that enables full interoperability with Rollup. With it comes
 very powerful bundling and tree-shaking of generated Typescript declaration files that works seamlessly with code splitting.
 
@@ -53,61 +53,19 @@ very powerful bundling and tree-shaking of generated Typescript declaration file
 
 ## Table of Contents
 
-- [Description](#description)
-  - [Features](#features)
+- [Description](#description) - [Features](#features)
 - [Table of Contents](#table-of-contents)
-- [Install](#install)
-  - [npm](#npm)
-  - [Yarn](#yarn)
-  - [pnpm](#pnpm)
-- [Usage](#usage)
-  - [Using it with just Typescript](#using-it-with-just-typescript)
-    - [Typescript and tslib helpers](#typescript-and-tslib-helpers)
-  - [Combining Typescript with a Browserslist](#combining-typescript-with-a-browserslist)
-    - [Using the plugin with Typescript, but without Browserslists](#using-the-plugin-with-typescript-but-without-browserslists)
-  - [Combining Typescript with Babel](#combining-typescript-with-babel)
-    - [Special handling for minification plugins/presets](#special-handling-for-minification-pluginspresets)
-    - [`@babel/runtime` and external helpers](#babelruntime-and-external-helpers)
-    - [`@babel/runtime` and polyfills](#babelruntime-and-polyfills)
-  - [Using `CustomTransformers`](#using-customtransformers)
+- [Install](#install) - [npm](#npm) - [Yarn](#yarn) - [pnpm](#pnpm)
+- [Usage](#usage) - [Using it with just Typescript](#using-it-with-just-typescript) - [Typescript and tslib helpers](#typescript-and-tslib-helpers) - [Combining Typescript with a Browserslist](#combining-typescript-with-a-browserslist) - [Using the plugin with Typescript, but without Browserslist](#using-the-plugin-with-typescript-but-without-browserslist) - [Combining Typescript with Babel](#combining-typescript-with-babel) - [Special handling for minification plugins/presets](#special-handling-for-minification-pluginspresets) - [`@babel/runtime` and external helpers](#babelruntime-and-external-helpers) - [`@babel/runtime` and polyfills](#babelruntime-and-polyfills) - [Using `CustomTransformers`](#using-customtransformers)
 - [Declaration files](#declaration-files)
-- [Examples](#examples)
-  - [Pure Typescript example](#pure-typescript-example)
-  - [Typescript with Browserslist example](#typescript-with-browserslist-example)
-  - [Typescript, Babel, and Browserslist example](#typescript-babel-and-browserslist-example)
-  - [Pure Typescript with CustomTransformers](#pure-typescript-with-customtransformers)
-  - [Advanced example of using Typescript, Babel, and Browserslists together](#advanced-example-of-using-typescript-babel-and-browserslists-together)
-  - [Passing a specific TypeScript version](#passing-a-specific-typescript-version)
-- [Hooks](#hooks)
-  - [The `outputPath` hook](#the-outputpath-hook)
-  - [The `diagnostics` hook](#the-diagnostics-hook)
-- [Full list of plugin options](#full-list-of-plugin-options)
-  - [`transpiler`](#transpiler)
-  - [`babelConfig`](#babelconfig)
-  - [`tsconfig`](#tsconfig)
-  - [`browserslist`](#browserslist)
-  - [`cwd`](#cwd)
-  - [`typescript`](#typescript)
-  - [`transformers`](#transformers)
-  - [`include`](#include)
-  - [`exclude`](#exclude)
-  - [`transpileOnly`](#transpileonly)
-  - [`fileSystem`](#filesystem)
-  - [`hook`](#hook)
-- [Ignored/overridden options](#ignoredoverridden-options)
-  - [Ignored/overridden Typescript options](#ignoredoverridden-typescript-options)
-  - [Ignored/overridden Babel options](#ignoredoverridden-babel-options)
-  - [Default Babel plugins](#default-babel-plugins)
+- [Examples](#examples) - [Pure Typescript example](#pure-typescript-example) - [Typescript with Browserslist example](#typescript-with-browserslist-example) - [Typescript, Babel, and Browserslist example](#typescript-babel-and-browserslist-example) - [Pure Typescript with CustomTransformers](#pure-typescript-with-customtransformers) - [Advanced example of using Typescript, Babel, and Browserslist together](#advanced-example-of-using-typescript-babel-and-browserslist-together) - [Passing a specific TypeScript version](#passing-a-specific-typescript-version)
+- [Hooks](#hooks) - [The `outputPath` hook](#the-outputpath-hook) - [The `diagnostics` hook](#the-diagnostics-hook)
+- [Full list of plugin options](#full-list-of-plugin-options) - [`transpiler`](#transpiler) - [`babelConfig`](#babelconfig) - [`tsconfig`](#tsconfig) - [`browserslist`](#browserslist) - [`cwd`](#cwd) - [`typescript`](#typescript) - [`transformers`](#transformers) - [`include`](#include) - [`exclude`](#exclude) - [`transpileOnly`](#transpileonly) - [`fileSystem`](#filesystem) - [`hook`](#hook)
+- [Ignored/overridden options](#ignoredoverridden-options) - [Ignored/overridden Typescript options](#ignoredoverridden-typescript-options) - [Ignored/overridden Babel options](#ignoredoverridden-babel-options) - [Default Babel plugins](#default-babel-plugins)
 - [Contributing](#contributing)
 - [Maintainers](#maintainers)
-- [Backers](#backers)
-  - [Patreon](#patreon)
-- [FAQ](#faq)
-  - [Does this plugin work with Code Splitting?](#does-this-plugin-work-with-code-splitting)
-  - [Why wouldn't you use just Typescript?](#why-wouldnt-you-use-just-typescript)
-  - [Okay, then why wouldn't you use just babel?](#okay-then-why-wouldnt-you-use-just-babel)
-  - [When combined with Babel, what does Typescript do, and what does Babel do?](#when-combined-with-babel-what-does-typescript-do-and-what-does-babel-do)
-  - [Why is @babel/plugin-transform-runtime and tslib included by default?](#why-is-babelplugin-transform-runtime-and-tslib-included-by-default)
+- [Backers](#backers) - [Patreon](#patreon)
+- [FAQ](#faq) - [Does this plugin work with Code Splitting?](#does-this-plugin-work-with-code-splitting) - [Why wouldn't you use just Typescript?](#why-wouldnt-you-use-just-typescript) - [Okay, then why wouldn't you use just babel?](#okay-then-why-wouldnt-you-use-just-babel) - [When combined with Babel, what does Typescript do, and what does Babel do?](#when-combined-with-babel-what-does-typescript-do-and-what-does-babel-do) - [Why is @babel/plugin-transform-runtime and tslib included by default?](#why-is-babelplugin-transform-runtime-and-tslib-included-by-default)
 - [License](#license)
 
 <!-- SHADOW_SECTION_TOC_END -->
@@ -119,19 +77,19 @@ very powerful bundling and tree-shaking of generated Typescript declaration file
 ### npm
 
 ```
-$ npm install @wessberg/rollup-plugin-ts
+$ npm install rollup-plugin-ts
 ```
 
 ### Yarn
 
 ```
-$ yarn add @wessberg/rollup-plugin-ts
+$ yarn add rollup-plugin-ts
 ```
 
 ### pnpm
 
 ```
-$ pnpm add @wessberg/rollup-plugin-ts
+$ pnpm add rollup-plugin-ts
 ```
 
 <!-- SHADOW_SECTION_INSTALL_END -->
@@ -145,7 +103,7 @@ $ pnpm add @wessberg/rollup-plugin-ts
 Using the plugin is as simple as it can be. Here's an example within a Rollup config:
 
 ```javascript
-import ts from "@wessberg/rollup-plugin-ts";
+import ts from "rollup-plugin-ts";
 export default {
 	// ...
 	plugins: [
@@ -206,7 +164,7 @@ ts({
 ```
 
 If there is a `.browserslistrc` file or the nearest `package.json` contains a Browserslist configuration, a target ECMAScript version will be decided based on that one, rather than respecting the `target` property of the matched `tsconfig`.
-If you do not want this behavior, you can [disable it as described here](#using-the-plugin-with-typescript-but-without-browserslists).
+If you do not want this behavior, you can [disable it as described here](#using-the-plugin-with-typescript-but-without-browserslist).
 
 #### Typescript and tslib helpers
 
@@ -245,7 +203,7 @@ ts({
 });
 ```
 
-#### Using the plugin with Typescript, but without Browserslists
+#### Using the plugin with Typescript, but without Browserslist
 
 If no Browserslist can be found, or if you simply don't want to use one, that's completely OK!
 In such cases, the `target` property of the nearest `tsconfig` will be used (or use the Typescript default setting if no such file exists).
@@ -343,7 +301,7 @@ ts({
 ### Typescript, Babel, and Browserslist example
 
 [As described here](#combining-typescript-with-babel), a `babel.config.js` or `.babelrc` file will automatically be found by the plugin if available. This example shows how you can provide one explicitly.
-And, [as described here](#typescript-with-browserslist-example), the same goes for Browserslists.
+And, [as described here](#typescript-with-browserslist-example), the same goes for Browserslist.
 
 ```javascript
 ts({
@@ -367,7 +325,7 @@ ts({
 });
 ```
 
-### Advanced example of using Typescript, Babel, and Browserslists together
+### Advanced example of using Typescript, Babel, and Browserslist together
 
 This example shows how you can use this plugin to accomplish quite advanced things:
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-	"name": "@wessberg/rollup-plugin-ts",
+	"name": "rollup-plugin-ts",
 	"version": "1.2.14",
-	"description": "A Typescript Rollup plugin that bundles declarations and respects Browserslists",
+	"description": "A Typescript Rollup plugin that bundles declarations and respects Browserslist",
 	"scripts": {
 		"generate:scaffold": "scaffold all --yes",
 		"generate:changelog": "standard-changelog --first-release",
@@ -51,7 +51,7 @@
 		"@rollup/plugin-commonjs": "^11.0.1",
 		"@rollup/plugin-json": "^4.0.1",
 		"@types/prettier": "^1.19.0",
-		"@wessberg/rollup-plugin-ts": "^1.2.13",
+		"rollup-plugin-ts": "npm:@wessberg/rollup-plugin-ts",
 		"@wessberg/scaffold": "^1.0.23",
 		"@wessberg/ts-config": "^0.0.44",
 		"ava": "3.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,6 @@ devDependencies:
   "@rollup/plugin-commonjs": 11.0.1_rollup@1.30.0
   "@rollup/plugin-json": 4.0.1_rollup@1.30.0
   "@types/prettier": 1.19.0
-  "@wessberg/rollup-plugin-ts": 1.2.13_rollup@1.30.0+typescript@3.7.5
   "@wessberg/scaffold": 1.0.23_typescript@3.7.5
   "@wessberg/ts-config": 0.0.44_tslint@6.0.0+typescript@3.7.5
   ava: 3.1.0
@@ -38,6 +37,7 @@ devDependencies:
   pretty-quick: 2.0.1_prettier@1.19.1
   rimraf: 3.0.0
   rollup: 1.30.0
+  rollup-plugin-ts: /@wessberg/rollup-plugin-ts/1.2.14_rollup@1.30.0+typescript@3.7.5
   standard-changelog: 2.0.21
   ts-node: 8.6.2_typescript@3.7.5
   tslint: 6.0.0_typescript@3.7.5
@@ -992,7 +992,7 @@ packages:
       node: ">=8.0.0"
     resolution:
       integrity: sha512-Ba1Q36FZhe1KrLWDkxUetrWCEIdmyPvndKp4zTirWHYnTfNyvr4adDIrQaIq1h49DkPDgQEkBw7PcMRSvuFA3g==
-  /@wessberg/rollup-plugin-ts/1.2.13_rollup@1.30.0+typescript@3.7.5:
+  /@wessberg/rollup-plugin-ts/1.2.14_rollup@1.30.0+typescript@3.7.5:
     dependencies:
       "@babel/core": 7.8.3
       "@babel/plugin-proposal-async-generator-functions": 7.8.3_@babel+core@7.8.3
@@ -1021,10 +1021,10 @@ packages:
     engines:
       node: ">=8.0.0"
     peerDependencies:
-      rollup: ^1.29.0
+      rollup: ^1.30.0
       typescript: ^3.x
     resolution:
-      integrity: sha512-uIGWrz909d6zvVRyl6xwkAdbNhc82RkgeC0RS/8907PTIr3nqkYbVuLVpTZeoOg2cBCXIP5HKP4paBNNNGRgcA==
+      integrity: sha512-dLJuWdI71EkpSUpeBxSer1pD/Ss6scSF43b5dU/Gaf0beyA76/Xex3cIRf1SFKCDbd5KEjvbR/HMwpxFQHS9/g==
   /@wessberg/scaffold/1.0.23_typescript@3.7.5:
     dependencies:
       "@types/eslint": 6.1.7
@@ -6296,7 +6296,6 @@ specifiers:
   "@types/node": ^13.5.0
   "@types/prettier": ^1.19.0
   "@wessberg/browserslist-generator": ^1.0.30
-  "@wessberg/rollup-plugin-ts": ^1.2.13
   "@wessberg/scaffold": ^1.0.23
   "@wessberg/stringutil": ^1.0.19
   "@wessberg/ts-clone-node": ^0.3.3
@@ -6314,6 +6313,7 @@ specifiers:
   pretty-quick: ^2.0.1
   rimraf: ^3.0.0
   rollup: ^1.30.0
+  rollup-plugin-ts: "npm:@wessberg/rollup-plugin-ts"
   slash: ^3.0.0
   standard-changelog: ^2.0.21
   ts-node: 8.6.2

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,4 @@
-import ts from "@wessberg/rollup-plugin-ts";
+import ts from "rollup-plugin-ts";
 import packageJson from "./package.json";
 
 import {builtinModules} from "module";


### PR DESCRIPTION
How do you think?