### PR TITLE
Bad behaviour when the same import is used in two namespaces

### DIFF
--- a/test/namespace-export.test.ts
+++ b/test/namespace-export.test.ts
@@ -149,3 +149,70 @@ test("Handles namespace exports. #3", async (t, {typescript}) => {
 	} = bundle;
 	t.deepEqual(formatCode(file.code), formatCode(`export * as Foo from "ava";`));
 });
+
+test("Handles namespace exports. #4", async (t, {typescript}) => {
+	if (lt(typescript.version, "3.8.0")) {
+		t.pass(`Current TypeScript version (${typescript.version} does not support 'export * as Foo from "..."' syntax. Skipping...`);
+		return;
+	}
+
+	const bundle = await generateRollupBundle(
+		[
+			{
+				entry: true,
+				fileName: "index.ts",
+				text: `\
+          		export * as Foo from "./foo";
+          		export * as Bar from "./bar";
+        	`
+			},
+			{
+				entry: false,
+				fileName: "foo.ts",
+				text: `\
+				import { Subscribable } from 'ava';
+
+				export interface Foo extends Subscribable {
+					a: number
+				}
+				`
+			},
+			{
+				entry: false,
+				fileName: "bar.ts",
+				text: `\
+				import { Subscribable } from 'ava';
+
+				export interface Bar extends Subscribable {
+					b: number;
+				}
+				`
+			}
+		],
+		{
+			typescript,
+			debug: false
+		}
+	);
+	const {
+		declarations: [file]
+	} = bundle;
+	t.deepEqual(
+		formatCode(file.code),
+		formatCode(`\
+			import { Subscribable } from "ava";
+			
+			declare namespace Foo {
+					interface Foo extends Subscribable {
+							a: number;
+					}
+			}
+			declare namespace Bar {
+				interface Bar extends Subscribable {
+						b: number;
+				}
+		}
+			export { Foo, Bar };
+		`)
+	);
+});


### PR DESCRIPTION
Hi,

you'll find in this PR, a test for a case that occurs in my code and lead to invalid imports.
I don't fill very confident to fix and, I'm not sure of the way you'll want to fix it, so I push you only the test (which is obviously failing).

Here is a summary of the case 

This ts files 

*index.ts*
```ts
export * as Foo from "./foo";
export * as Bar from "./bar";
```

*foo.ts*
```ts
import { Subscribable } from 'ava';

export interface Foo extends Subscribable {
  a: number
}
```

*bar.ts*
```ts
import { Subscribable } from 'ava';

export interface Bar extends Subscribable {
  b: number;
} 
```

lead to this `d.ts` 

```ts
declare namespace Foo {
  import { Subscribable } from "ava";
  interface Foo extends Subscribable {
	a: number;
   }
}

declare namespace Bar {
  interface Bar extends Subscribable {
	b: number;
  }
}
export { Foo, Bar };
```

which is invalid, we need an `import Subscribable` at the top of the file.

Thx for your lib :)