### PR TITLE
fix: swc reject when set parser to typescript

### DIFF
--- a/src/transpiler/swc.ts
+++ b/src/transpiler/swc.ts
@@ -62,7 +62,7 @@ export function getSwcConfigFactory({fileSystem, swcConfig, cwd, browserslist, p
 				...inputConfig.jsc,
 				parser: {
 					syntax: "ecmascript",
-					jsx: false,
+					...(inputConfig.jsc?.parser?.syntax === "typescript" ? {} : {jsx: false}),
 					...inputConfig.jsc?.parser
 				},
 				...FORCED_SWC_JSC_OPTIONS


### PR DESCRIPTION
swc will throw "unknown field `jsx`, expected one of `tsx`" when swcConfig.jsc.parser.syntax="typescript"
![image](https://user-images.githubusercontent.com/13846369/142828177-ed59bebc-7329-424d-a801-ceaf5badd1a7.png)
