### PR TITLE
feat: add possibility to disable externalHelpers

### DIFF
--- a/src/constant/constant.ts
+++ b/src/constant/constant.ts
@@ -92,9 +92,7 @@ export const FORCED_SWC_MODULE_OPTIONS = {
 	type: "es6"
 } as const;
 
-export const FORCED_SWC_JSC_OPTIONS = {
-	externalHelpers: true
-} as const;
+export const FORCED_SWC_JSC_OPTIONS = {} as const;
 
 export const FORCED_BABEL_PRESET_ENV_OPTIONS = {
 	modules: false

--- a/src/transpiler/swc.ts
+++ b/src/transpiler/swc.ts
@@ -62,6 +62,8 @@ export function getSwcConfigFactory({fileSystem, swcConfig, cwd, browserslist, e
 			jsc: {
 				// Loose breaks things such as spreading an iterable that isn't an array
 				loose: false,
+				// By default, import @swc/helpers instead of inlining them
+				externalHelpers: true,
 				...inputConfig.jsc,
 				parser: {
 					syntax: "ecmascript",

--- a/test/swc.test.ts
+++ b/test/swc.test.ts
@@ -120,6 +120,48 @@ test.serial("Can use swc for transpilation. #2", withTypeScript, async (t, {type
 	);
 });
 
+test.serial("Can use swc without externalHelpers", withTypeScript, async (t, {typescript}) => {
+	const bundle = await generateRollupBundle(
+		[
+			{
+				entry: true,
+				fileName: "index.ts",
+				text: `\
+					typeof "";
+					`
+			}
+		],
+		{
+			typescript,
+			transpiler: "swc",
+			loadSwcHelpers: true,
+			swcConfig: {
+				jsc: {
+					externalHelpers: false,
+				}
+			},
+			exclude: [],
+			tsconfig: {
+				target: "es5",
+				allowJs: true
+			}
+		}
+	);
+	const {
+		js: [file]
+	} = bundle;
+
+	t.deepEqual(
+		formatCode(file.code),
+		formatCode(`\
+		var _typeof = function(obj) {
+			return obj && typeof Symbol !== "undefined" && obj.constructor === Symbol ? "symbol" : typeof obj;
+		};
+		_typeof("");
+		`)
+	);
+});
+
 test.serial("Supports swc minification. #1", withTypeScript, async (t, {typescript}) => {
 	const bundle = await generateRollupBundle(
 		[


### PR DESCRIPTION
Hi! While working on library packages, I decided to use rollup and rollup-plugin-ts. While I was building the packages, every time externalHelpers was imported in build. This would force projects which depends on packages to also include @swc/helpers.

This PR removes forced use of externalHelpers. By default, externalHelpers are used, but developer can opt-out of this.
