### PR TITLE
fix: Babel transpiler fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,11 +122,11 @@
 		"tslib": "^2.6.1"
 	},
 	"peerDependencies": {
-		"@babel/core": ">=6.x || >=7.x",
-		"@babel/runtime": ">=6.x || >=7.x",
-		"@babel/preset-env": ">=6.x || >=7.x",
-		"@babel/preset-typescript": ">=6.x || >=7.x",
-		"@babel/plugin-transform-runtime": ">=6.x || >=7.x",
+		"@babel/core": ">=7.x",
+		"@babel/runtime": ">=7.x",
+		"@babel/preset-env": ">=7.x",
+		"@babel/preset-typescript": ">=7.x",
+		"@babel/plugin-transform-runtime": ">=7.x",
 		"@swc/core": ">=1.x",
 		"@swc/helpers": ">=0.2",
 		"rollup": ">=1.x || >=2.x || >=3.x",

--- a/src/transpiler/babel.ts
+++ b/src/transpiler/babel.ts
@@ -52,7 +52,8 @@ export function getForcedBabelOptions({cwd}: GetForcedBabelOptionsOptions): Tran
 		sourceType: "module",
 		plugins: [
 			// Needed to make babel understand dynamic imports
-			resolveModule("@babel/plugin-syntax-dynamic-import")
+			// TODO: Add @babel/plugin-syntax-dynamic-import as an optional peer for next major
+			resolveModule("@babel/plugin-syntax-dynamic-import", resolveModule("@babel/preset-env"))
 		]
 	};
 }

--- a/src/util/path/path-util.ts
+++ b/src/util/path/path-util.ts
@@ -20,7 +20,7 @@ import {ensureArray} from "../ensure-array/ensure-array.js";
 import {createRequire} from "module";
 
 // Until import.meta.resolve becomes stable, we'll have to do this instead
-export const resolveModule = createRequire(import.meta.url).resolve;
+export const resolveModule = (id: string, from: string = import.meta.url) => createRequire(from).resolve(id);
 
 export function isTypeScriptLib(p: string): boolean {
 	return p.startsWith(`lib.`) && p.endsWith(D_TS_EXTENSION);


### PR DESCRIPTION
A few fixes for when using Babel as transpiler.

### ~~Babel and `browserslist: false`~~

~~Remove all Babel transformation plugins when using `browserslist: false` [as documented](https://github.com/wessberg/rollup-plugin-ts/blob/84e1b7289f052221e383ec55abc636d7278e20eb/README.md#babelpreset-env-behavior-and-how-to-opt-out)~~

~~Fixes #189~~

### `@babel/plugin-syntax-dynamic-import` resolution

Resolving `@babel/plugin-syntax-dynamic-import` directly is unsound since it is neither a dependency nor a peer dependency. pnpm is supposed to forbid this but don't know why it didn't. Resolve it from `@babel/present-env`

Fixes #185

### `@babel/*` peers

`@babel/*` packages didn't exist until Babel 7. Remove extraneous `>=6.x` from peer version ranges.