### PR TITLE
Fix yarn install command in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ $ npm install @babel/core @babel/runtime @babel/plugin-transform-runtime @babel/
 **Yarn**
 
 ```
-$ yarn add @babel/core @babel/runtime @babel/plugin-transform-runtime @babel-preset-typescript @babel/preset-env --dev
+$ yarn add @babel/core @babel/runtime @babel/plugin-transform-runtime @babel/preset-typescript @babel/preset-env --dev
 ```
 
 **pnpm**


### PR DESCRIPTION
`@babel-preset-typescript` does not exist, `@babel-preset-typescript` does.

Am I the only one using `yarn` these days?