### PR TITLE
Add TypeScript 4.9.5 and 5.0.2 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,8 @@
 		"typescript-4-5-4": "npm:typescript@4.5.4",
 		"typescript-4-6-4": "npm:typescript@4.6.4",
 		"typescript-4-7-2": "npm:typescript@4.7.2",
-		"typescript-4-8-2": "npm:typescript@4.8.2"
+		"typescript-4-8-2": "npm:typescript@4.8.2",
+		"typescript-4-9-5": "npm:typescript@4.9.5"
 	},
 	"dependencies": {
 		"@rollup/pluginutils": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,8 @@
 		"typescript-4-6-4": "npm:typescript@4.6.4",
 		"typescript-4-7-2": "npm:typescript@4.7.2",
 		"typescript-4-8-2": "npm:typescript@4.8.2",
-		"typescript-4-9-5": "npm:typescript@4.9.5"
+		"typescript-4-9-5": "npm:typescript@4.9.5",
+		"typescript-5-0-2": "npm:typescript@5.0.2"
 	},
 	"dependencies": {
 		"@rollup/pluginutils": "^5.0.2",
@@ -126,7 +127,7 @@
 		"@swc/core": ">=1.x",
 		"@swc/helpers": ">=0.2",
 		"rollup": ">=1.x || >=2.x",
-		"typescript": ">=3.2.x || >= 4.x"
+		"typescript": ">=3.2.x || >= 4.x || >= 5.x"
 	},
 	"peerDependenciesMeta": {
 		"@babel/core": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,6 +67,7 @@ specifiers:
   typescript-4-6-4: npm:typescript@4.6.4
   typescript-4-7-2: npm:typescript@4.7.2
   typescript-4-8-2: npm:typescript@4.8.2
+  typescript-4-9-5: npm:typescript@4.9.5
 
 dependencies:
   '@rollup/pluginutils': 5.0.2_rollup@3.10.1
@@ -8080,6 +8081,12 @@ packages:
     resolution: {integrity: sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==}
     engines: {node: '>=4.2.0'}
     hasBin: true
+
+  /typescript/4.9.5:
+    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
+    dev: true
 
   /ua-parser-js/1.0.33:
     resolution: {integrity: sha512-RqshF7TPTE0XLYAqmjlu5cLLuGdKrNu9O1KLA/qp39QtbZwuzwv1dT46DZSopoUMsYgXpB3Cv8a03FI8b74oFQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,7 @@ specifiers:
   typescript-4-7-2: npm:typescript@4.7.2
   typescript-4-8-2: npm:typescript@4.8.2
   typescript-4-9-5: npm:typescript@4.9.5
+  typescript-5-0-2: npm:typescript@5.0.2
 
 dependencies:
   '@rollup/pluginutils': 5.0.2_rollup@3.10.1
@@ -8085,6 +8086,12 @@ packages:
   /typescript/4.9.5:
     resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
     engines: {node: '>=4.2.0'}
+    hasBin: true
+    dev: true
+
+  /typescript/5.0.2:
+    resolution: {integrity: sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==}
+    engines: {node: '>=12.20'}
     hasBin: true
     dev: true
 

--- a/test/tslib.test.ts
+++ b/test/tslib.test.ts
@@ -3,7 +3,7 @@ import {withTypeScriptVersions} from "./util/ts-macro.js";
 import {generateRollupBundle} from "./setup/setup-rollup.js";
 import {formatCode} from "./util/format-code.js";
 
-test.serial("Will treat every file as a module with tslib. #1", withTypeScriptVersions(">=3.6"), async (t, {typescript}) => {
+test.serial("Will treat every file as a module with tslib. #1", withTypeScriptVersions(">=3.6 <5.0"), async (t, {typescript}) => {
 	const bundle = await generateRollupBundle(
 		[
 			{
@@ -22,6 +22,47 @@ test.serial("Will treat every file as a module with tslib. #1", withTypeScriptVe
 
 			tsconfig: {
 				target: "es3",
+				lib: ["esnext"]
+			}
+		}
+	);
+	const {
+		bundle: {
+			output: [file]
+		}
+	} = bundle;
+
+	t.deepEqual(
+		formatCode(file.code),
+		formatCode(`\
+				import { __awaiter, __generator } from 'tslib';
+
+				(function () { return __awaiter(void 0, void 0, void 0, function () { return __generator(this, function (_a) {
+						return [2 /*return*/];
+				}); }); })();
+			`)
+	);
+});
+
+test.serial("Will treat every file as a module with tslib. #2", withTypeScriptVersions(">=5.0"), async (t, {typescript}) => {
+	const bundle = await generateRollupBundle(
+		[
+			{
+				entry: true,
+				fileName: "index.ts",
+				text: `\
+						(async () => {})();
+					`
+			}
+		],
+		{
+			typescript,
+			rollupOptions: {
+				external: ["tslib"]
+			},
+
+			tsconfig: {
+				target: "es5",
 				lib: ["esnext"]
 			}
 		}


### PR DESCRIPTION
This adds support for TS 4.9 and 5.0.

For 5.0, due to [deprecations](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#deprecations-and-default-changes), a tslib test variation had to be added, which changes tsconfig `target` from `es3` to `es5`.